### PR TITLE
[Enhancement] Adding a --version switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,14 @@ matrix:
       osx_image: xcode9.2 # 10.12
 
 install: true
+env: REQVER=1.12
 script: >-
   bash tests/install.sh &&
   source ~/.bashrc &&
   bash tests/validate.sh &&
+  bash tests/remove.sh
+  
+  bash tests/version.sh &&
+  source ~/.bashrc &&
+  bash tests/version-validate.sh &&
   bash tests/remove.sh

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -69,8 +69,7 @@ elif [ "$1" == "--version" ]; then
     if [ -z "$2" ]; then # Check if --version has a second positional parameter
         echo "Please provide a version number for: $1"
     else
-        VERSION=$2\
-    
+        VERSION=$2
     fi
 elif [ ! -z "$1" ]; then
     echo "Unrecognized option: $1"

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.12.5"
+VERSION="1.12.6"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -68,7 +68,6 @@ elif [ "$1" == "--help" ]; then
 elif [ "$1" == "--version" ]; then
     if [ -z "$2" ]; then # Check if --version has a second positional parameter
         echo "Please provide a version number for: $1"
-        
     else
         VERSION=$2
 fi

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -69,8 +69,9 @@ elif [ "$1" == "--version" ]; then
     if [ -z "$2" ]; then # Check if --version has a second positional parameter
         echo "Please provide a version number for: $1"
     else
-        VERSION=$2
-fi
+        VERSION=$2\
+    
+    fi
 elif [ ! -z "$1" ]; then
     echo "Unrecognized option: $1"
     exit 1

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.12.7"
+VERSION="1.13"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -36,6 +36,7 @@ print_help() {
     echo "Usage: bash goinstall.sh OPTIONS"
     echo -e "\nOPTIONS:"
     echo -e "  --remove\tRemove currently installed version"
+    echo -e "  --version\tSpecify a version number to install"
 }
 
 if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]; then
@@ -43,8 +44,6 @@ if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]; then
 elif [ -n "`$SHELL -c 'echo $BASH_VERSION'`" ]; then
     shell_profile="bashrc"
 fi
-
-PACKAGE_NAME="go$VERSION.$PLATFORM.tar.gz"
 
 if [ "$1" == "--remove" ]; then
     rm -rf "$GOROOT"
@@ -66,6 +65,13 @@ if [ "$1" == "--remove" ]; then
 elif [ "$1" == "--help" ]; then
     print_help
     exit 0
+elif [ "$1" == "--version" ]; then
+    if [ -z "$2" ]; then # Check if --version has a second positional parameter
+        echo "Please provide a version number for: $1"
+        
+    else
+        VERSION=$2
+fi
 elif [ ! -z "$1" ]; then
     echo "Unrecognized option: $1"
     exit 1
@@ -75,6 +81,8 @@ if [ -d "$GOROOT" ]; then
     echo "The Go install directory ($GOROOT) already exists. Exiting."
     exit 1
 fi
+
+PACKAGE_NAME="go$VERSION.$PLATFORM.tar.gz"
 
 echo "Downloading $PACKAGE_NAME ..."
 if hash wget 2>/dev/null; then

--- a/tests/version-validate.sh
+++ b/tests/version-validate.sh
@@ -1,0 +1,36 @@
+set -e
+echo "Go environment after setup:"
+env | grep "^GO"
+
+mkdir -p "$GOPATH/src/hello"
+pushd "$GOPATH/src/hello"
+echo "Writing hello.go"
+cat >hello.go <<EOF
+package main
+import (
+    "fmt"
+    "runtime"
+)
+func main() {
+    fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}
+EOF
+echo "Building hello test project"
+go build
+echo "Install hello test project"
+go install
+echo "Run hello test project"
+hello
+popd
+
+GOVER=`go version`
+
+echo "Testing to make sure that Go $REQVER is installed\n"
+
+if grep -q "$REQVER" <<< "$GOVER"; then
+	echo "Version contains: $REQVER"
+	exit 0
+else
+	echo "Does not contain: $REQVER"
+	exit 1
+fi

--- a/tests/version-validate.sh
+++ b/tests/version-validate.sh
@@ -25,7 +25,7 @@ popd
 
 GOVER=`go version`
 
-echo "Testing to make sure that Go $REQVER is installed\n"
+echo "Testing to make sure that Go $REQVER is installed"
 
 if grep -q "$REQVER" <<< "$GOVER"; then
 	echo "Version contains: $REQVER"

--- a/tests/version.sh
+++ b/tests/version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+unset GOROOT
+unset GOPATH
+"$(dirname "$0")/../goinstall.sh" --version $REQVER


### PR DESCRIPTION
### **Suggestion:**
I suggest adding a --version switch to the script to allow for the installation of versions that are not the same as the hardcoded version number on the script. This way if someone wants to install a newer/older version they don't have to wait on the script to be updated to show the new version or edit the scrip themselves.

### **Changes:**

Added --version to help

Added --version switch for hardcoded version override.

Added if statement to check for --version
If there is nothing provided after version the script will continue with the hardcoded version.

Moved package name down to allow for the new version switch to change the package name.