### PR TITLE
Use mktemp instead of just /tmp/

### DIFF
--- a/goinstall.sh
+++ b/goinstall.sh
@@ -82,7 +82,7 @@ if [ -d "$GOROOT" ]; then
 fi
 
 PACKAGE_NAME="go$VERSION.$PLATFORM.tar.gz"
-TEMP_DIRECTORY=$(mktemp)
+TEMP_DIRECTORY=$(mktemp -d)
 
 echo "Downloading $PACKAGE_NAME ..."
 if hash wget 2>/dev/null; then

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -82,12 +82,13 @@ if [ -d "$GOROOT" ]; then
 fi
 
 PACKAGE_NAME="go$VERSION.$PLATFORM.tar.gz"
+TEMP_DIRECTORY=$(mktemp)
 
 echo "Downloading $PACKAGE_NAME ..."
 if hash wget 2>/dev/null; then
-    wget https://storage.googleapis.com/golang/$PACKAGE_NAME -O /tmp/go.tar.gz
+    wget https://storage.googleapis.com/golang/$PACKAGE_NAME -O "$TEMP_DIRECTORY/go.tar.gz"
 else
-    curl -o /tmp/go.tar.gz https://storage.googleapis.com/golang/$PACKAGE_NAME
+    curl -o "$TEMP_DIRECTORY/go.tar.gz" https://storage.googleapis.com/golang/$PACKAGE_NAME
 fi
 
 if [ $? -ne 0 ]; then
@@ -97,7 +98,7 @@ fi
 
 echo "Extracting File..."
 mkdir -p "$GOROOT"
-tar -C "$GOROOT" --strip-components=1 -xzf /tmp/go.tar.gz
+tar -C "$GOROOT" --strip-components=1 -xzf "$TEMP_DIRECTORY/go.tar.gz"
 touch "$HOME/.${shell_profile}"
 {
     echo '# GoLang'
@@ -111,4 +112,4 @@ mkdir -p $GOPATH/{src,pkg,bin}
 echo -e "\nGo $VERSION was installed into $GOROOT.\nMake sure to relogin into your shell or run:"
 echo -e "\n\tsource $HOME/.${shell_profile}\n\nto update your environment variables."
 echo "Tip: Opening a new terminal window usually just works. :)"
-rm -f /tmp/go.tar.gz
+rm -f "$TEMP_DIRECTORY/go.tar.gz"


### PR DESCRIPTION
Hello!

I noticed that sometimes there is a problem with downloading Go directly to `/tmp`, so I modified the script a bit to use `mktemp`.

![Successfully ran install.sh test](https://user-images.githubusercontent.com/24775963/78424903-f0683f80-7670-11ea-82c0-cf3d0fc34c17.png)

(Fish causes `Is a directory` error, I will send another pull request addressing this issue 😄)

Thanks for the script!