### PR TITLE
Add aarch64 support

### DIFF
--- a/goinstall.sh
+++ b/goinstall.sh
@@ -15,6 +15,9 @@ case $OS in
         "x86_64")
             ARCH=amd64
             ;;
+        "aarch64")
+            ARCH=arm64
+            ;;
         "armv6")
             ARCH=armv6l
             ;;


### PR DESCRIPTION
Hello!

It is a bit related to #32, adds a case for aarch64 devices like rpi4.

![Successfully installed on Rpi4](https://user-images.githubusercontent.com/24775963/78446346-c36c5a80-7679-11ea-95f6-51e7a3fdc67e.png)

