### PR TITLE
Add armv7l support

### DIFF
--- a/goinstall.sh
+++ b/goinstall.sh
@@ -22,6 +22,9 @@ case $OS in
         "armv6")
             ARCH=armv6l
             ;;
+        "armv7l")
+            ARCH=armv6l
+            ;;
         "armv8")
             ARCH=arm64
             ;;

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -19,10 +19,7 @@ case $OS in
         "aarch64")
             ARCH=arm64
             ;;
-        "armv6")
-            ARCH=armv6l
-            ;;
-        "armv7l")
+        "armv6" | "armv7l")
             ARCH=armv6l
             ;;
         "armv8")


### PR DESCRIPTION
Adds a case for armv7l devices like rpi3. #32
```
$ uname -a
Linux Balder 5.4.83-v7+ #1379 SMP Mon Dec 14 13:08:57 GMT 2020 armv7l GNU/Linux
```