### PR TITLE
Automatically Install latest version

### DIFF
--- a/goinstall.sh
+++ b/goinstall.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # shellcheck disable=SC2016
 set -e
-TEMP="/tmp/golang-install-page.html"
 
+TEMP_DIRECTORY=$(mktemp -d)
+TEMP=${TEMP_DIRECTORY}"/go-page.html"
 curl -k "https://go.dev/dl/" -o $TEMP -s
 
 HTML_TAG_VERSION=$(grep -i -o '<span>go.*</span>' $TEMP | sed -n '6p')
@@ -10,7 +11,7 @@ TAG_VERSION=${HTML_TAG_VERSION:8}
 GO_LATEST_VERSION=${TAG_VERSION%<*}
 
 VERSION=$GO_LATEST_VERSION
-# VERSION="1.20.6"
+rm -f "$TEMP_DIRECTORY/go-page.html"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"
@@ -131,7 +132,6 @@ if [ -d "$GOROOT" ]; then
 fi
 
 PACKAGE_NAME="go$VERSION.$PLATFORM.tar.gz"
-TEMP_DIRECTORY=$(mktemp -d)
 
 echo "Downloading $PACKAGE_NAME ..."
 if hash wget 2>/dev/null; then

--- a/goinstall.sh
+++ b/goinstall.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 # shellcheck disable=SC2016
 set -e
+TEMP="/tmp/golang-install-page.html"
 
-VERSION="1.20.6"
+curl -k "https://go.dev/dl/" -o $TEMP -s
+
+HTML_TAG_VERSION=$(grep -i -o '<span>go.*</span>' $TEMP | sed -n '6p')
+TAG_VERSION=${HTML_TAG_VERSION:8}
+GO_LATEST_VERSION=${TAG_VERSION%<*}
+
+VERSION=$GO_LATEST_VERSION
+# VERSION="1.20.6"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"


### PR DESCRIPTION
When executing the file without passing parameters, the script will find the latest LTS version of golang through web scrapping the download page of the official website and change the VERSION variable